### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ plugins:
 
 # Site settings
 url: 'https://mydomain.com'
-baseurl: ''
+baseurl: 'LakeWaterLevelData'
 title: 'My website'
 description: 'This is my new website'
 permalink: pretty


### PR DESCRIPTION
Changing the baseurl to LakeWaterLevelData should make the website work and look pretty I think. I tested it on my fork. The template was designed for personal github pages rather than a project github pages which needs the baseurl to be the repository name.